### PR TITLE
Feature anchor-offset

### DIFF
--- a/themes/introit16/static/scss/style.scss
+++ b/themes/introit16/static/scss/style.scss
@@ -74,6 +74,21 @@ h2 {
   margin-top: 1.5em;
   border-bottom: 1px solid #ddd;
 }
+/* Offset anchor links */
+h1:before,
+h2:before,
+h3:before,
+h4:before,
+h5:before,
+h6:before {
+    display: block;
+    content: " ";
+    margin-top: -65px;
+    height: 65px;
+    visibility: hidden;
+}
+
+
 kbd,
 code {
   padding: 2px 4px;
@@ -370,7 +385,7 @@ header nav ul li.active a {
 .card {
   width: 45%;
   width: 380px;
-  margin: 0 1.5% 5% 1.5%;
+  margin: 0 1.5% 35px 1.5%;
   float: left;
   position: relative;
   color: #aaa;

--- a/themes/introit16/static/scss/style.scss
+++ b/themes/introit16/static/scss/style.scss
@@ -74,17 +74,18 @@ h2 {
   margin-top: 1.5em;
   border-bottom: 1px solid #ddd;
 }
-/* Offset anchor links */
-h1:before,
-h2:before,
-h3:before,
-h4:before,
-h5:before,
-h6:before {
+
+/* Offset anchor links on h-tags in content */
+#content h1:before,
+#content h2:before,
+#content h3:before,
+#content h4:before,
+#content h5:before,
+#content h6:before {
     display: block;
     content: " ";
-    margin-top: -65px;
-    height: 65px;
+    margin-top: -75px;
+    height: 75px;
     visibility: hidden;
 }
 


### PR DESCRIPTION
Jag har lagt till CSS som skapar ett pseudo-element för varje header i content och därmed förskjuter var webbläsaren stannar vid länkning. Ett problem som ev. kan uppstå är att det osynliga pseudo-elementet täcker länkar i föregående paragrafer, men i alla tester jag gjort har detta inte varit ett problem då länkarna gått klicka på i vilket fall.

Jag har testat att det fungerar på:
- **Linux Mint**
    + Mozilla Firefox
- **Windows 10**
    + Microsoft Edge 38.14393.0.0
    + Internet Explorer 11
    + Google Chrome 52.0.2743.116 m
    + Mozilla Firefox 47.0.1
- **Mac OS X 10.11 (El Capitan)**
    + Safari 9.1.2
    + Google Chrome 52.0.2743.116

Jag har även justerat marginal på modulkorten för att fungera korrekt i firefox.

***
This closes #46 and closes #53 